### PR TITLE
Test array with same elements. Test fails

### DIFF
--- a/lib/ascii_chart/line.rb
+++ b/lib/ascii_chart/line.rb
@@ -20,6 +20,7 @@ module AsciiChart
 
       @options[:height] ||= interval
       radio = @options[:height].to_f / interval
+      radio = 1.0 if radio.nan? || radio == Float::INFINITY
       offset = @options[:offset]
 
       intmax = (max * radio).ceil
@@ -31,6 +32,7 @@ module AsciiChart
 
       (intmin..intmax).each do |y|
         label = @options[:format] % (max - (((y - intmin) * interval).to_f / rows))
+        label = @options[:format] % y if rows == 0
         result[y - intmin][[offset - label.length, 0].max] = label
         result[y - intmin][offset - 1] = y == 0 ? '┼' : '┤'
       end

--- a/test/ascii_chart_test.rb
+++ b/test/ascii_chart_test.rb
@@ -6,4 +6,14 @@ class AsciiChartTest < Minitest::Test
   def test_that_it_has_a_version_number
     refute_nil ::AsciiChart::VERSION
   end
+
+  def test_writes_array_same_numbers
+    input_array = [4, 4, 4, 4.00, 4, 4, 4, 4, 4, 4]
+    assert_equal(AsciiChart.plot(input_array), '    4.00  ┼--------- ')
+  end
+
+  def test_writes_array_same_numbers_and_height_provided
+    input_array = [4, 4, 4, 4.00, 4, 4, 4, 4, 4, 4]
+    assert_equal(AsciiChart.plot(input_array, { height: 10 }), '    4.00  ┼--------- ')
+  end
 end


### PR DESCRIPTION
Solve issue #4 

In case the height argument is provided along with an array filled by the same number, check out the graph plotted: it has `height == 1`. It makes sense, because if you want to plot: `[4, 4, 4, 4]`, it makes sense to have a chart with a straight line: it's height will be 1.

But sinse a height is provided as param, I'd expect the chart to be filled with a eg 4 blank lines above and 5 lines below. Or maybe 9 lines above and 0 lines below? I don't know. I'll let it as it is and you can make the call on how do you want it.

Maybe a follow up task could be: add a new param to fill padding top and bottom of the graph, and use that new function to add padding to a graph that has drawn an array with same values and a height as param.